### PR TITLE
Fix GitHub Pages path and orbital visuals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/OrbitalVisualization.tsx
+++ b/src/components/OrbitalVisualization.tsx
@@ -100,12 +100,13 @@ const OrbitalVisualization = ({ orbitalType, isAnimating }: OrbitalVisualization
   });
 
   return (
-    <group ref={groupRef}>
-      {/* Orbital Path - more visible with thicker line */}
-      <mesh>
-        <primitive object={pathGeometry} attach="geometry" />
-        <lineBasicMaterial attach="material" color="#8b5cf6" opacity={0.8} transparent linewidth={3} />
-      </mesh>
+    <>
+      <group ref={groupRef}>
+        {/* Orbital Path - more visible with thicker line */}
+        <mesh>
+          <primitive object={pathGeometry} attach="geometry" />
+          <lineBasicMaterial attach="material" color="#ff00ff" opacity={0.8} transparent linewidth={3} />
+        </mesh>
 
       {/* Animated Electron */}
       <mesh ref={electronRef}>
@@ -117,6 +118,12 @@ const OrbitalVisualization = ({ orbitalType, isAnimating }: OrbitalVisualization
         />
       </mesh>
 
+        {/* Nucleus representation */}
+        <mesh position={[0, 0, 0]}>
+          <sphereGeometry args={[0.08]} />
+          <meshPhongMaterial color="#8b5cf6" emissive="#7c3aed" emissiveIntensity={0.2} />
+        </mesh>
+      </group>
       {/* Static Coordinate System - positioned outside the rotating group */}
       <group>
         {/* X-axis */}
@@ -153,13 +160,7 @@ const OrbitalVisualization = ({ orbitalType, isAnimating }: OrbitalVisualization
           <meshBasicMaterial color="#3b82f6" />
         </mesh>
       </group>
-
-      {/* Nucleus representation */}
-      <mesh position={[0, 0, 0]}>
-        <sphereGeometry args={[0.08]} />
-        <meshPhongMaterial color="#8b5cf6" emissive="#7c3aed" emissiveIntensity={0.2} />
-      </mesh>
-    </group>
+    </>
   );
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === 'development' ? '/' : '/orbital-quantum-visuals/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set correct `base` path for GitHub Pages
- use `BASE_URL` for the router
- keep axes stationary while orbital rotates
- use neon magenta for orbital path

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68505620fc9083328c76be80b46defd8