### PR TITLE
Fix CommandDialogProps definition

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (


### PR DESCRIPTION
## Summary
- remove empty interface in Command component and replace with a type alias

## Testing
- `npm run lint` *(fails: ESLint found errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850581278888332ae4d50c3d55eedc9